### PR TITLE
Fixed search bar border background transparency

### DIFF
--- a/main.css
+++ b/main.css
@@ -302,3 +302,9 @@ div[data-test-id="chat-window-container"] {
 .T3r {
   background: rgb(from var(--pdt-l1) r g b / 6.4%);
 }
+
+/* Search bar upper and bottom part */
+div.Lfz.MIw.ojN.zI7.iyn.Hsu,
+div.Lfz.MIw.QLY.zI7.iyn.Hsu{
+  background-image: none !important;
+}


### PR DESCRIPTION
There was a common issue that was bothering me with this theme, literally the only thing I thought that wasn't a great design, that was the search bar having white spots. I managed to fix them disabling the background-image, that's the property that was in the original Pinterest code. I don't know if you as the main dev will like the class notation, but feel free to change and roast it, LOL. Anyway it's really a minor change. I've tested using brave but I'm pretty sure that it works on firefox.